### PR TITLE
feat: add release pipeline with PyPI publishing and dynamic versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release Pipeline
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+      - run: pip install -e ".[dev]"
+      - run: ruff check .
+      - run: ruff format --check .
+
+  test:
+    needs: lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: pip install -e ".[dev]"
+      - run: pytest
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+      - run: pip install build
+      - run: python -m build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,3 +35,9 @@ engraft apply --template <file> --values <file>  # run the tool
 - Linting: ruff (rules: E, F, I, UP, B)
 - Testing: pytest, tests mirror src structure (`tests/test_actions/`)
 - Line length: 88 characters
+- Versioning: hatch-vcs (version derived from git tags, not hardcoded)
+
+## CI/CD
+
+- **PR pipeline** (`.github/workflows/pr.yml`): lint, format check, test matrix (3.10, 3.12, 3.13)
+- **Release pipeline** (`.github/workflows/release.yml`): triggered on GitHub Release publish → lint → format check → test matrix → build → publish to PyPI (Trusted Publisher OIDC + Sigstore signing)

--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ Replace an entire file with a source file referenced by a variable.
 
 The variable value is a path relative to the values file directory. Useful for binary files like images.
 
+## Releasing
+
+Versioning is automatic via [hatch-vcs](https://github.com/ofek/hatch-vcs) — the package version is derived from git tags.
+
+To publish a new release:
+
+1. Create a GitHub Release with a tag matching `vX.Y.Z` (e.g., `v0.2.0`)
+2. The release pipeline automatically runs lint, format check, and tests
+3. If all checks pass, the package is built and published to PyPI with Sigstore signing
+
 ## Development
 
 ```bash

--- a/openspec/changes/archive/2026-04-04-release-pipeline/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-04-release-pipeline/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-04

--- a/openspec/changes/archive/2026-04-04-release-pipeline/design.md
+++ b/openspec/changes/archive/2026-04-04-release-pipeline/design.md
@@ -1,0 +1,44 @@
+## Context
+
+The project uses hatchling for building and has an existing PR pipeline (`.github/workflows/pr.yml`) that runs ruff lint, ruff format check, and pytest across Python 3.10/3.12/3.13. There is no release automation — publishing to PyPI is not yet set up. The version is hardcoded as `0.1.0` in `pyproject.toml`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Automate PyPI publishing on every GitHub Release
+- Gate releases on the same quality checks as PRs (lint, format, test)
+- Use modern PyPI authentication (Trusted Publisher / OIDC) — no stored API tokens
+- Sign releases with Sigstore attestations
+- Derive package version from git tags via hatch-vcs
+
+**Non-Goals:**
+- TestPyPI publishing (not needed, Trusted Publisher is already configured)
+- Changelog generation or release notes automation
+- Multi-platform wheel builds (pure Python package, universal wheel is sufficient)
+- Reusable workflow extraction (duplicating checks is simpler for this project size)
+
+## Decisions
+
+### 1. Trigger: `on: release: types: [published]`
+**Rationale**: The user wants to use GitHub's Release UI. This trigger fires when a release is published (which also creates a tag). Preferred over `on: push: tags` because it ties the workflow to an intentional release action, not just any tag push.
+
+### 2. Trusted Publisher with OIDC (no API tokens)
+**Rationale**: PyPI's Trusted Publisher feature uses GitHub's OIDC identity provider. The workflow gets a short-lived token automatically — no secrets to rotate or leak. This is PyPI's recommended approach. Requires a GitHub environment named `pypi` with `id-token: write` permission.
+
+### 3. Sigstore signing via `pypa/gh-action-pypi-publish`
+**Rationale**: The `pypa/gh-action-pypi-publish` action supports `attestations: true` which generates Sigstore attestations automatically. This provides cryptographic proof that the package was built from this repository. No additional tooling needed.
+
+### 4. hatch-vcs for dynamic versioning
+**Rationale**: Eliminates version string duplication between `pyproject.toml` and git tags. The version is the single source of truth from the tag. Requires adding `hatch-vcs` as a build dependency and switching to `dynamic = ["version"]` in `pyproject.toml`. Alternative considered: manual version bumps with a CI validation step — rejected because it adds friction and is error-prone.
+
+### 5. Duplicate quality checks (don't reuse PR workflow)
+**Rationale**: The quality gate jobs are small (lint + format + test). Extracting a reusable workflow adds indirection without meaningful DRY benefit at this project size. Duplication keeps the release workflow self-contained and easy to understand.
+
+### 6. Build with `python -m build`
+**Rationale**: Standard Python packaging tool that produces both sdist and wheel. Works with hatchling backend. The `build` package is installed in the CI job, not added as a project dependency.
+
+## Risks / Trade-offs
+
+- **[Tag/version mismatch]** → hatch-vcs derives version from tags. If a release is created without a proper `v*` tag prefix, the version may be unexpected. Mitigation: document tag format convention (`vX.Y.Z`).
+- **[OIDC trust scope]** → The GitHub environment `pypi` must be correctly configured. If misconfigured, the publish step will fail with an auth error. Mitigation: clear error message from the action; one-time setup already done.
+- **[Duplicated CI logic]** → Quality checks exist in both `pr.yml` and `release.yml`. If one is updated, the other may drift. Mitigation: acceptable trade-off for simplicity; both files are small and co-located.

--- a/openspec/changes/archive/2026-04-04-release-pipeline/proposal.md
+++ b/openspec/changes/archive/2026-04-04-release-pipeline/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The project has no automated release process. Publishing to PyPI is manual and error-prone, with no guarantee that quality checks pass before a release goes out. A release pipeline triggered by GitHub Releases ensures every published version is linted, tested, and signed.
+
+## What Changes
+
+- Add a GitHub Actions workflow (`release.yml`) triggered on `release: published` events that runs lint/format/test gates, builds the package, and publishes to PyPI via Trusted Publisher OIDC with Sigstore signing.
+- Switch from hardcoded version in `pyproject.toml` to `hatch-vcs` so the package version is derived automatically from git tags.
+- Add `build` as a build-time or CI dependency for producing sdist and wheel artifacts.
+
+## Capabilities
+
+### New Capabilities
+- `release-pipeline`: GitHub Actions workflow for automated quality-gated release and PyPI publishing
+- `dynamic-versioning`: Switch to hatch-vcs for git-tag-based version derivation
+
+### Modified Capabilities
+- `pr-ci-pipeline`: No requirement change — the release pipeline duplicates the same checks independently
+
+## Impact
+
+- **Files added**: `.github/workflows/release.yml`
+- **Files modified**: `pyproject.toml` (versioning config, build dependencies)
+- **Dependencies added**: `hatch-vcs` (build-time), `build` (CI-only)
+- **External config required**: GitHub environment `pypi` must exist with OIDC trust; Trusted Publisher already configured on pypi.org

--- a/openspec/changes/archive/2026-04-04-release-pipeline/specs/dynamic-versioning/spec.md
+++ b/openspec/changes/archive/2026-04-04-release-pipeline/specs/dynamic-versioning/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Version is derived from git tags
+The package version SHALL be dynamically derived from git tags using `hatch-vcs` instead of being hardcoded in `pyproject.toml`.
+
+#### Scenario: Tagged commit (release build)
+- **WHEN** the current commit has a tag matching `v*` (e.g., `v0.2.0`)
+- **THEN** the package version SHALL be the tag version without the `v` prefix (e.g., `0.2.0`)
+
+#### Scenario: Untagged commit (development build)
+- **WHEN** the current commit does not have a version tag
+- **THEN** the package version SHALL be a dev version derived from the nearest tag (e.g., `0.2.0.dev3+gabcdef`)
+
+### Requirement: pyproject.toml uses dynamic version field
+The `pyproject.toml` SHALL declare `dynamic = ["version"]` and remove the hardcoded `version` field. The `[tool.hatch.version]` section SHALL specify `source = "vcs"`.
+
+#### Scenario: pyproject.toml configuration
+- **WHEN** inspecting `pyproject.toml`
+- **THEN** the `[project]` section SHALL contain `dynamic = ["version"]` and SHALL NOT contain a `version` key
+- **THEN** the `[tool.hatch.version]` section SHALL contain `source = "vcs"`
+
+### Requirement: hatch-vcs is a build dependency
+The `hatch-vcs` package SHALL be listed in the `[build-system] requires` array.
+
+#### Scenario: Build system includes hatch-vcs
+- **WHEN** inspecting `pyproject.toml` `[build-system]` section
+- **THEN** the `requires` array SHALL include `hatch-vcs`

--- a/openspec/changes/archive/2026-04-04-release-pipeline/specs/release-pipeline/spec.md
+++ b/openspec/changes/archive/2026-04-04-release-pipeline/specs/release-pipeline/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Release workflow triggers on GitHub Release publish
+The release workflow SHALL be triggered when a GitHub Release is published (`on: release: types: [published]`).
+
+#### Scenario: Release is published via GitHub UI
+- **WHEN** a user publishes a GitHub Release
+- **THEN** the release workflow starts execution
+
+#### Scenario: Draft release is created
+- **WHEN** a user creates a draft release without publishing
+- **THEN** the release workflow SHALL NOT trigger
+
+### Requirement: Quality gate runs lint and format checks
+The release workflow SHALL run `ruff check .` and `ruff format --check .` as a quality gate before building.
+
+#### Scenario: Lint check passes
+- **WHEN** all source files pass ruff lint rules
+- **THEN** the workflow proceeds to the test stage
+
+#### Scenario: Lint or format check fails
+- **WHEN** any source file fails ruff lint or format check
+- **THEN** the workflow SHALL fail and NOT proceed to build or publish
+
+### Requirement: Quality gate runs tests across Python matrix
+The release workflow SHALL run `pytest` across Python versions 3.10, 3.12, and 3.13.
+
+#### Scenario: All tests pass on all Python versions
+- **WHEN** pytest passes on Python 3.10, 3.12, and 3.13
+- **THEN** the workflow proceeds to the build stage
+
+#### Scenario: Tests fail on any Python version
+- **WHEN** pytest fails on any matrix version
+- **THEN** the workflow SHALL fail and NOT proceed to build or publish
+
+### Requirement: Build produces sdist and wheel artifacts
+The release workflow SHALL build both an sdist and a wheel using `python -m build`.
+
+#### Scenario: Successful build
+- **WHEN** the quality gate passes
+- **THEN** the workflow builds sdist and wheel artifacts in `dist/`
+
+### Requirement: Publish to PyPI using Trusted Publisher OIDC
+The release workflow SHALL publish to PyPI using `pypa/gh-action-pypi-publish` with OIDC authentication (no API tokens). The job SHALL use the `pypi` GitHub environment.
+
+#### Scenario: Successful publish
+- **WHEN** build artifacts exist and OIDC authentication succeeds
+- **THEN** the package is published to pypi.org
+
+#### Scenario: OIDC authentication fails
+- **WHEN** the Trusted Publisher configuration is missing or misconfigured
+- **THEN** the publish step SHALL fail with an authentication error
+
+### Requirement: Releases are signed with Sigstore attestations
+The release workflow SHALL enable Sigstore attestations (`attestations: true`) when publishing.
+
+#### Scenario: Package is published with attestation
+- **WHEN** a package is successfully published to PyPI
+- **THEN** Sigstore attestations SHALL be generated for the published artifacts
+
+### Requirement: Publish depends on all quality gates passing
+The publish job SHALL only run after lint, format, test, and build jobs all succeed.
+
+#### Scenario: Quality gate fails
+- **WHEN** any quality gate job (lint, test) fails
+- **THEN** the build and publish jobs SHALL NOT execute

--- a/openspec/changes/archive/2026-04-04-release-pipeline/tasks.md
+++ b/openspec/changes/archive/2026-04-04-release-pipeline/tasks.md
@@ -1,0 +1,12 @@
+## 1. Dynamic Versioning
+
+- [x] 1.1 Update `pyproject.toml`: add `hatch-vcs` to `[build-system] requires`
+- [x] 1.2 Update `pyproject.toml`: remove hardcoded `version`, add `dynamic = ["version"]`, add `[tool.hatch.version]` with `source = "vcs"`
+
+## 2. Release Workflow
+
+- [x] 2.1 Create `.github/workflows/release.yml` with `on: release: types: [published]` trigger
+- [x] 2.2 Add lint job: checkout, setup Python 3.13, install deps, run `ruff check .` and `ruff format --check .`
+- [x] 2.3 Add test job (depends on lint): checkout, setup Python matrix (3.10, 3.12, 3.13), install deps, run `pytest`
+- [x] 2.4 Add build job (depends on test): checkout, setup Python 3.13, install `build`, run `python -m build`, upload `dist/` as artifact
+- [x] 2.5 Add publish job (depends on build): use `pypi` environment, download artifact, publish with `pypa/gh-action-pypi-publish` with `attestations: true`, set `id-token: write` permission

--- a/openspec/specs/dynamic-versioning/spec.md
+++ b/openspec/specs/dynamic-versioning/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Version is derived from git tags
+The package version SHALL be dynamically derived from git tags using `hatch-vcs` instead of being hardcoded in `pyproject.toml`.
+
+#### Scenario: Tagged commit (release build)
+- **WHEN** the current commit has a tag matching `v*` (e.g., `v0.2.0`)
+- **THEN** the package version SHALL be the tag version without the `v` prefix (e.g., `0.2.0`)
+
+#### Scenario: Untagged commit (development build)
+- **WHEN** the current commit does not have a version tag
+- **THEN** the package version SHALL be a dev version derived from the nearest tag (e.g., `0.2.0.dev3+gabcdef`)
+
+### Requirement: pyproject.toml uses dynamic version field
+The `pyproject.toml` SHALL declare `dynamic = ["version"]` and remove the hardcoded `version` field. The `[tool.hatch.version]` section SHALL specify `source = "vcs"`.
+
+#### Scenario: pyproject.toml configuration
+- **WHEN** inspecting `pyproject.toml`
+- **THEN** the `[project]` section SHALL contain `dynamic = ["version"]` and SHALL NOT contain a `version` key
+- **THEN** the `[tool.hatch.version]` section SHALL contain `source = "vcs"`
+
+### Requirement: hatch-vcs is a build dependency
+The `hatch-vcs` package SHALL be listed in the `[build-system] requires` array.
+
+#### Scenario: Build system includes hatch-vcs
+- **WHEN** inspecting `pyproject.toml` `[build-system]` section
+- **THEN** the `requires` array SHALL include `hatch-vcs`

--- a/openspec/specs/release-pipeline/spec.md
+++ b/openspec/specs/release-pipeline/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Release workflow triggers on GitHub Release publish
+The release workflow SHALL be triggered when a GitHub Release is published (`on: release: types: [published]`).
+
+#### Scenario: Release is published via GitHub UI
+- **WHEN** a user publishes a GitHub Release
+- **THEN** the release workflow starts execution
+
+#### Scenario: Draft release is created
+- **WHEN** a user creates a draft release without publishing
+- **THEN** the release workflow SHALL NOT trigger
+
+### Requirement: Quality gate runs lint and format checks
+The release workflow SHALL run `ruff check .` and `ruff format --check .` as a quality gate before building.
+
+#### Scenario: Lint check passes
+- **WHEN** all source files pass ruff lint rules
+- **THEN** the workflow proceeds to the test stage
+
+#### Scenario: Lint or format check fails
+- **WHEN** any source file fails ruff lint or format check
+- **THEN** the workflow SHALL fail and NOT proceed to build or publish
+
+### Requirement: Quality gate runs tests across Python matrix
+The release workflow SHALL run `pytest` across Python versions 3.10, 3.12, and 3.13.
+
+#### Scenario: All tests pass on all Python versions
+- **WHEN** pytest passes on Python 3.10, 3.12, and 3.13
+- **THEN** the workflow proceeds to the build stage
+
+#### Scenario: Tests fail on any Python version
+- **WHEN** pytest fails on any matrix version
+- **THEN** the workflow SHALL fail and NOT proceed to build or publish
+
+### Requirement: Build produces sdist and wheel artifacts
+The release workflow SHALL build both an sdist and a wheel using `python -m build`.
+
+#### Scenario: Successful build
+- **WHEN** the quality gate passes
+- **THEN** the workflow builds sdist and wheel artifacts in `dist/`
+
+### Requirement: Publish to PyPI using Trusted Publisher OIDC
+The release workflow SHALL publish to PyPI using `pypa/gh-action-pypi-publish` with OIDC authentication (no API tokens). The job SHALL use the `pypi` GitHub environment.
+
+#### Scenario: Successful publish
+- **WHEN** build artifacts exist and OIDC authentication succeeds
+- **THEN** the package is published to pypi.org
+
+#### Scenario: OIDC authentication fails
+- **WHEN** the Trusted Publisher configuration is missing or misconfigured
+- **THEN** the publish step SHALL fail with an authentication error
+
+### Requirement: Releases are signed with Sigstore attestations
+The release workflow SHALL enable Sigstore attestations (`attestations: true`) when publishing.
+
+#### Scenario: Package is published with attestation
+- **WHEN** a package is successfully published to PyPI
+- **THEN** Sigstore attestations SHALL be generated for the published artifacts
+
+### Requirement: Publish depends on all quality gates passing
+The publish job SHALL only run after lint, format, test, and build jobs all succeed.
+
+#### Scenario: Quality gate fails
+- **WHEN** any quality gate job (lint, test) fails
+- **THEN** the build and publish jobs SHALL NOT execute

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "engraft"
-version = "0.1.0"
 description = "Apply customizations to any project without templating placeholders"
+dynamic = ["version"]
 requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
@@ -19,6 +19,9 @@ dev = ["ruff>=0.4", "pytest>=7.0"]
 
 [project.scripts]
 engraft = "engraft.cli:main"
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/engraft"]


### PR DESCRIPTION
Add GitHub Actions release workflow triggered on GitHub Release publish events. The pipeline runs lint, format check, and test matrix before building and publishing to PyPI via Trusted Publisher OIDC with Sigstore signing. Switch from hardcoded version to hatch-vcs for automatic git-tag-based versioning.