### PR TITLE
fix: correct license identifier and add readme to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ name = "engraft"
 description = "Apply customizations to any project without templating placeholders"
 dynamic = ["version"]
 requires-python = ">=3.10"
-license = "MIT"
+license = "BSD-2-Clause"
+readme = "README.md"
 dependencies = [
     "click>=8.0",
     "lxml>=5.0",


### PR DESCRIPTION
Set license to BSD-2-Clause to match LICENSE file and add readme field so PyPI displays the project README.

Closes #3