### PR TITLE
feat: optional variables with noop semantics for unset values (#4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,16 +6,18 @@ CLI tool that applies customizations to any project without requiring templating
 
 ```
 CLI (cli.py)
- └─ engine.apply()          # resolves variables, runs actions in order
+ └─ engine.apply()          # resolves variables, builds actions, runs them
      ├─ models.py            # parses template + values YAML files
      └─ actions/             # plugin registry for action types
-         ├─ __init__.py      # registry: @register decorator + create_action()
-         ├─ base.py          # Action ABC (apply method)
+         ├─ __init__.py      # registry: @register decorator + get_action_class()
+         ├─ base.py          # Action ABC (zero-arg apply method)
          ├─ json_replace.py  # JSONPath-like selectors
          ├─ html_replace.py  # XPath selectors via lxml
          ├─ regex_replace.py # named capture group (?P<value>...)
          └─ file_replace.py  # whole-file replacement
 ```
+
+Actions are fully resolved at construction: each holds `target: Path`, `selector: str`, `value: str` (or `target: Path`, `source_path: Path` for file_replace). `apply()` takes no arguments. The engine expands multi-entry `replace` lists into individual actions and skips entries for unset variables.
 
 New actions: create a dataclass in `actions/`, use `@register("name")`, import it in `actions/__init__.py`.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Create a template file `engraft.template.yml`:
 
 ```yaml
 variables:
-  app_name:
+  - variable: app_name
     description: Application name
     default: DefaultApp
 
@@ -74,6 +74,22 @@ Result — `config.json` now contains:
   "version": "1.0.0"
 }
 ```
+
+## Optional Variables
+
+Variables without a `default` are optional. If the values file doesn't provide a value, any action referencing that variable is silently skipped (noop):
+
+```yaml
+variables:
+  - variable: app_name
+    description: Application name
+    default: DefaultApp       # always applied (falls back to default)
+  - variable: theme_color
+    description: Primary theme color
+                              # no default — skipped unless values file sets it
+```
+
+This lets template authors define customization points that consumers can opt into without requiring every variable to be set.
 
 ## Action Reference
 

--- a/openspec/changes/archive/2026-04-09-optional-variables-noop/design.md
+++ b/openspec/changes/archive/2026-04-09-optional-variables-noop/design.md
@@ -1,0 +1,70 @@
+## Context
+
+The engine currently treats every variable as required with a mandatory `default`. The `Variable` dataclass holds `default: str`, and `parse_template` falls back to `""` when no default is given. Actions receive a `variables: dict[str, str]` in `apply()` and blindly use whatever value is present — including empty strings from missing defaults.
+
+Actions also hold a `replace: list[dict]` allowing multiple selector/variable pairs per action. This means a single action can reference multiple variables, complicating the question of "what happens when one variable is set and another isn't."
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow variables without a `default` — these are unset unless the values file provides them
+- Actions referencing unset variables are never constructed (noop by absence)
+- Switch variables YAML from dict to array format for consistency with customizations
+- Flatten actions to single-variable, single-selector — fully resolved at construction
+- `apply()` becomes a zero-argument method; actions are self-contained deferred operations
+
+**Non-Goals:**
+- Multi-variable actions or template interpolation within a single action
+- Validation or warning system for unset variables (may come later)
+- Changes to the values YAML format
+- Changes to CLI interface
+
+## Decisions
+
+### 1. Variables as array in template YAML
+
+Use `- variable: name` entries instead of dict keys. This mirrors the `customizations` format and avoids overloading YAML dict keys as identifiers.
+
+**Alternative**: Keep dict format, just make `default` optional. Rejected because it's inconsistent with how customizations are defined.
+
+### 2. `Variable.default` becomes `str | None`
+
+`None` means "no default provided." During resolution, if neither the values file nor the default supplies a value, the variable is absent from the resolved dict.
+
+**Alternative**: Use a sentinel string like `"__UNSET__"`. Rejected — `None` is idiomatic Python and avoids collision with legitimate values.
+
+### 3. Expand multi-entry actions at parse/construction time
+
+A YAML customization with `replace: [{selector: ..., variable: ...}, ...]` is expanded into N individual action objects, one per entry. Each holds a single `selector` and the resolved `value`.
+
+**Alternative**: Keep the list internally and have actions loop + skip unset entries. Rejected — pushing noop logic into every action duplicates responsibility and complicates the action interface.
+
+### 4. Inject all dependencies at action construction
+
+Actions receive `value`, `target` (absolute path to file in staging dir), and `values_dir` (for `file_replace` source resolution) at construction time. `apply()` takes no arguments.
+
+**Alternative**: Pass `work_dir` and `values_dir` to `apply()`. Rejected — the user's preference is to make actions fully self-contained at construction.
+
+### 5. Skip unset variables during action construction
+
+The engine builds the resolved variables dict (only set keys), then iterates customization entries. For each entry, if the referenced variable is absent from the dict, the action is not created. No filtering loop needed later — the action list only contains executable actions.
+
+**Alternative**: Create all actions, mark some as noop, filter before execution. Rejected — unnecessary complexity; not creating the action is simpler than creating and skipping it.
+
+### 6. `file_replace` source path resolved at construction
+
+`file_replace` uses its variable value as a file path. The absolute source path (`values_dir / value`) is resolved at construction and stored on the action. `apply()` copies from `source_path` to `target` without needing `values_dir`.
+
+### 7. Target file collection remains a class-level concern
+
+`target_files()` is needed before staging dir creation (to know which files to copy). Since actions are constructed after staging, `target_files()` must work from the raw YAML data, not from action instances. This means the engine extracts `file` fields from customization entries directly, before action construction.
+
+**Alternative**: Two-phase construction (create actions for target_files, then inject paths). Rejected — over-engineered for extracting a `file` field from a dict.
+
+## Risks / Trade-offs
+
+**Breaking change to template YAML format** — Existing templates using dict-style variables will break. This is acceptable since the project is pre-1.0 and no external consumers exist yet.
+
+**Single-variable actions increase object count** — A customization with 5 replace entries becomes 5 action objects instead of 1. This is negligible for the expected scale of templates.
+
+**`target_files()` extracted from raw YAML, not from actions** — Slight duplication of knowing which field holds the file path. Mitigated by keeping the extraction simple (just read `file` key from each customization entry).

--- a/openspec/changes/archive/2026-04-09-optional-variables-noop/proposal.md
+++ b/openspec/changes/archive/2026-04-09-optional-variables-noop/proposal.md
@@ -1,0 +1,57 @@
+# Optional Variables with Noop Semantics
+
+## Problem
+
+Today every variable requires a `default`. If no default is given, it silently resolves to an empty string, which corrupts target files. There is no way to define an optional customization point — one that only applies when the consumer explicitly provides a value.
+
+## Proposed Change
+
+1. **Make `default` optional** — a variable without a default is "unset" unless the values file provides it.
+2. **Switch variables to array format** — consistent with `customizations`, using `- variable: name` instead of dict keys.
+3. **Flatten actions to single-variable** — each action operates on exactly one variable with one selector. Multi-entry `replace` lists in YAML are expanded at parse time.
+4. **Fully resolve actions at construction** — actions receive their resolved value, target path (via `work_dir`/`staging_dir`), and source dir (`values_dir`) at construction time. `apply()` becomes a zero-argument method.
+5. **Skip unset variables** — actions referencing unset variables are simply not created. No noop logic in actions themselves.
+
+## Template YAML Format Change
+
+```yaml
+# Before
+variables:
+  app_name:
+    description: "Application name"
+    default: "MyApp"
+  theme_color:
+    description: "Primary color"
+
+# After
+variables:
+  - variable: app_name
+    description: "Application name"
+    default: "MyApp"
+  - variable: theme_color
+    description: "Primary color"
+```
+
+## Engine Flow
+
+```
+1. Parse template YAML → variables list + raw customization entries
+2. Parse values YAML → flat dict
+3. Resolve variables: merge defaults + values → dict (only set keys)
+4. Create staging dir
+5. Copy target files into staging
+6. Expand customization entries into single-variable actions,
+   skipping any entry whose variable is absent from resolved dict.
+   Inject resolved value + staging_dir + values_dir at construction.
+7. Execute: for action in actions: action.apply()
+8. Copy back, clean up staging
+```
+
+## Impact
+
+- **models.py**: `Variable.default` becomes `str | None`, parse variables from array format
+- **engine.py**: new resolution + expansion + filtering logic, action construction with all deps
+- **actions/base.py**: `apply()` signature becomes `apply(self) -> None`
+- **All action classes**: hold resolved value + paths as fields, drop internal loops
+- **Specs**: update `variable-resolution`, `engine`, `unified-action-format`
+- **Tests**: update to match new YAML format and action construction

--- a/openspec/changes/archive/2026-04-09-optional-variables-noop/specs/engine/spec.md
+++ b/openspec/changes/archive/2026-04-09-optional-variables-noop/specs/engine/spec.md
@@ -1,0 +1,59 @@
+## MODIFIED Requirements
+
+### Requirement: Template YAML parsing
+The engine SHALL parse a template YAML file containing a `variables` array and a `customizations` list. Each customization entry SHALL specify an `action` field that maps to a registered action type. Multi-entry `replace` lists SHALL be expanded into individual single-variable action objects at parse time.
+
+#### Scenario: Valid template parsed
+- **WHEN** the engine reads a template YAML with variables array and customizations
+- **THEN** it produces a list of Variable objects and a list of raw customization entries
+
+#### Scenario: Empty variables section
+- **WHEN** the template YAML has no `variables` key or an empty array
+- **THEN** the engine proceeds with an empty variables list
+
+#### Scenario: Empty customizations section
+- **WHEN** the template YAML has no `customizations` key or an empty list
+- **THEN** the engine proceeds with no actions to execute
+
+#### Scenario: Multi-entry replace list expanded
+- **WHEN** a customization has `replace: [{selector: "$.name", variable: "app_name"}, {selector: "$.theme", variable: "theme"}]`
+- **THEN** the engine creates two separate action objects, one per entry
+
+### Requirement: Target file collection
+Each customization entry in the raw YAML SHALL contain a `file` field. The engine SHALL extract and deduplicate `file` values from all customization entries to determine which files to copy into the staging directory.
+
+#### Scenario: Single-file actions
+- **WHEN** customization entries target `src/config.json` and `assets/index.html`
+- **THEN** both files are copied into the staging directory
+
+#### Scenario: Duplicate file targets
+- **WHEN** multiple customization entries target the same file `src/config.json`
+- **THEN** the file is copied into the staging directory once
+
+## ADDED Requirements
+
+### Requirement: Actions constructed with resolved values
+Action objects SHALL receive the resolved variable value, the absolute target file path (within staging dir), and the values directory path at construction time. The `apply()` method SHALL take no arguments.
+
+#### Scenario: Action receives resolved value
+- **WHEN** a `json_replace` action is constructed for variable `app_name` with resolved value `"Foo"`
+- **THEN** the action object holds `value="Foo"` and `apply()` uses it directly
+
+#### Scenario: Action receives absolute target path
+- **WHEN** a `json_replace` action targets `src/config.json` and the staging dir is `/repo/.engraft`
+- **THEN** the action object holds `target=Path("/repo/.engraft/src/config.json")`
+
+### Requirement: Unset variables skip action creation
+When expanding customization entries into actions, the engine SHALL skip any entry whose referenced variable is absent from the resolved variables dict. No action object is created for unset variables.
+
+#### Scenario: Unset variable skipped
+- **WHEN** a customization references variable `theme_color` which has no default and no value provided
+- **THEN** no action is created for that entry
+
+#### Scenario: Set variable creates action
+- **WHEN** a customization references variable `app_name` which resolves to `"Foo"`
+- **THEN** an action is created with the resolved value
+
+#### Scenario: Mixed set and unset in same customization
+- **WHEN** a customization has two replace entries, one referencing a set variable and one referencing an unset variable
+- **THEN** only the action for the set variable is created; the unset entry is skipped

--- a/openspec/changes/archive/2026-04-09-optional-variables-noop/specs/unified-action-format/spec.md
+++ b/openspec/changes/archive/2026-04-09-optional-variables-noop/specs/unified-action-format/spec.md
@@ -1,4 +1,4 @@
-## ADDED Requirements
+## MODIFIED Requirements
 
 ### Requirement: json_replace action with selector-variable list
 The `json_replace` action YAML entry SHALL accept a `replace` list of `{selector, variable}` entries for convenience. At parse time, each entry SHALL be expanded into a separate `JsonReplace` action object holding a single `selector`, the resolved `value`, and the absolute `target` path. The `apply()` method SHALL take no arguments.
@@ -59,14 +59,3 @@ The `html_replace` action YAML entry SHALL accept a `replace` list of `{selector
 #### Scenario: Multiple HTML replacements on same file
 - **WHEN** the YAML entry has two replace entries targeting different XPath selectors
 - **THEN** two separate `HtmlReplace` action objects SHALL be created
-
-### Requirement: Consistent action naming
-All actions SHALL use the `*_replace` naming convention: `json_replace`, `html_replace`, `regex_replace`, `file_replace`.
-
-#### Scenario: Actions registered under new names
-- **WHEN** a template YAML uses `action: json_replace`
-- **THEN** the action registry SHALL resolve to the `JsonReplace` action class
-
-#### Scenario: Old action names rejected
-- **WHEN** a template YAML uses `action: json_set` (old name)
-- **THEN** the action registry SHALL raise an error indicating the action is unknown

--- a/openspec/changes/archive/2026-04-09-optional-variables-noop/specs/variable-resolution/spec.md
+++ b/openspec/changes/archive/2026-04-09-optional-variables-noop/specs/variable-resolution/spec.md
@@ -1,4 +1,4 @@
-## ADDED Requirements
+## MODIFIED Requirements
 
 ### Requirement: Variables defined with description and default
 Each variable in the template YAML SHALL be defined as an array entry with a `variable` field (name), a `description` field, and an optional `default` field. When `default` is not provided, the variable is unset unless the values file supplies a value.
@@ -30,12 +30,7 @@ Variables provided in the values file SHALL override the defaults from the templ
 - **WHEN** a template defines variable `theme_color` without a default and the values file does not include `theme_color`
 - **THEN** `theme_color` is absent from the resolved variables dict
 
-### Requirement: All action values reference variable names
-Customization actions SHALL reference variable names, not inline literal values. The resolved variable value is used at apply time.
-
-#### Scenario: Action references variable
-- **WHEN** an action specifies `replace: primary_color`
-- **THEN** the action uses the resolved value of the `primary_color` variable
+## ADDED Requirements
 
 ### Requirement: Variables use array format
 Variables in the template YAML SHALL be defined as an array of objects, each with a `variable` field as the identifier, a `description` field, and an optional `default` field.

--- a/openspec/changes/archive/2026-04-09-optional-variables-noop/tasks.md
+++ b/openspec/changes/archive/2026-04-09-optional-variables-noop/tasks.md
@@ -1,0 +1,34 @@
+## 1. Models and Variable Parsing
+
+- [x] 1.1 Update `Variable` dataclass: change `default: str` to `default: str | None`
+- [x] 1.2 Rewrite `parse_template` to parse variables from array format (`- variable: name`) with optional `default`
+- [x] 1.3 Add duplicate variable name detection in `parse_template`
+- [x] 1.4 Update/add tests for new variable parsing (array format, optional default, duplicates)
+
+## 2. Action Base Class and Subclasses
+
+- [x] 2.1 Change `Action.apply()` signature to `apply(self) -> None` (no parameters)
+- [x] 2.2 Refactor `JsonReplace`: single `selector: str`, `value: str`, `target: Path` fields; remove `replace` list and internal loop
+- [x] 2.3 Refactor `RegexReplace`: single `selector: str`, `value: str`, `target: Path` fields; remove `replace` list and internal loop
+- [x] 2.4 Refactor `HtmlReplace`: single `selector: str`, `value: str`, `target: Path` fields; remove `replace` list and internal loop
+- [x] 2.5 Refactor `FileReplace`: `source_path: Path`, `target: Path` fields; resolve source at construction
+- [x] 2.6 Remove `target_files()` from `Action` ABC (no longer needed on instances)
+- [x] 2.7 Update/add tests for all refactored action classes
+
+## 3. Engine Refactor
+
+- [x] 3.1 Implement variable resolution: merge defaults + values, omit unset variables from dict
+- [x] 3.2 Extract target files from raw YAML customization entries (before action construction)
+- [x] 3.3 Implement action expansion: iterate customization entries, expand `replace` lists, skip entries with unset variables, construct actions with resolved value + paths
+- [x] 3.4 Simplify execution loop to `action.apply()` with no arguments
+- [x] 3.5 Update/add engine tests: unset variable skipping, mixed set/unset, full apply flow
+
+## 4. Action Registry Update
+
+- [x] 4.1 Update `create_action` / registry to support new constructor signatures (value, target, values_dir)
+- [x] 4.2 Update action imports and registration in `actions/__init__.py`
+
+## 5. Integration and CLI
+
+- [x] 5.1 Run full test suite and fix any regressions
+- [x] 5.2 Run ruff lint and format checks, fix issues

--- a/openspec/specs/engine/spec.md
+++ b/openspec/specs/engine/spec.md
@@ -1,19 +1,23 @@
 ## ADDED Requirements
 
 ### Requirement: Template YAML parsing
-The engine SHALL parse a template YAML file containing a `variables` map and a `customizations` list. Each customization entry SHALL specify an `action` field that maps to a registered action type.
+The engine SHALL parse a template YAML file containing a `variables` array and a `customizations` list. Each customization entry SHALL specify an `action` field that maps to a registered action type. Multi-entry `replace` lists SHALL be expanded into individual single-variable action objects at parse time.
 
 #### Scenario: Valid template parsed
-- **WHEN** the engine reads a template YAML with variables and customizations
-- **THEN** it produces a Template model with resolved Variable objects and instantiated Action objects
+- **WHEN** the engine reads a template YAML with variables array and customizations
+- **THEN** it produces a list of Variable objects and a list of raw customization entries
 
 #### Scenario: Empty variables section
-- **WHEN** the template YAML has no `variables` key or an empty variables map
-- **THEN** the engine proceeds with an empty variables dict
+- **WHEN** the template YAML has no `variables` key or an empty array
+- **THEN** the engine proceeds with an empty variables list
 
 #### Scenario: Empty customizations section
 - **WHEN** the template YAML has no `customizations` key or an empty list
 - **THEN** the engine proceeds with no actions to execute
+
+#### Scenario: Multi-entry replace list expanded
+- **WHEN** a customization has `replace: [{selector: "$.name", variable: "app_name"}, {selector: "$.theme", variable: "theme"}]`
+- **THEN** the engine creates two separate action objects, one per entry
 
 ### Requirement: Values YAML parsing
 The engine SHALL parse a values YAML file into a flat string-to-string dictionary.
@@ -88,12 +92,17 @@ The engine SHALL execute all actions against a staging directory (`.engraft/`) a
 
 ### Requirement: Target file collection
 
-Each action SHALL expose a `target_files()` method returning the list of project-relative file paths it operates on. The engine SHALL collect and deduplicate these paths to determine which files to copy into the staging directory.
+Each customization entry in the raw YAML SHALL contain a `file` field. The engine SHALL extract and deduplicate `file` values from all customization entries to determine which files to copy into the staging directory.
 
 #### Scenario: Single-file actions
 
-- **WHEN** a `json_replace`, `html_replace`, `regex_replace`, or `file_replace` action targets `src/config.json`
-- **THEN** `target_files()` returns `["src/config.json"]`
+- **WHEN** customization entries target `src/config.json` and `assets/index.html`
+- **THEN** both files are copied into the staging directory
+
+#### Scenario: Duplicate file targets
+
+- **WHEN** multiple customization entries target the same file `src/config.json`
+- **THEN** the file is copied into the staging directory once
 
 ### Requirement: Staging directory preserves structure
 
@@ -112,3 +121,29 @@ The `file_replace` action SHALL verify that the target file exists before applyi
 
 - **WHEN** `file_replace` targets a file that does not exist in the work directory
 - **THEN** a `FileNotFoundError` is raised with a message identifying the missing target path
+
+### Requirement: Actions constructed with resolved values
+Action objects SHALL receive the resolved variable value, the absolute target file path (within staging dir), and the values directory path at construction time. The `apply()` method SHALL take no arguments.
+
+#### Scenario: Action receives resolved value
+- **WHEN** a `json_replace` action is constructed for variable `app_name` with resolved value `"Foo"`
+- **THEN** the action object holds `value="Foo"` and `apply()` uses it directly
+
+#### Scenario: Action receives absolute target path
+- **WHEN** a `json_replace` action targets `src/config.json` and the staging dir is `/repo/.engraft`
+- **THEN** the action object holds `target=Path("/repo/.engraft/src/config.json")`
+
+### Requirement: Unset variables skip action creation
+When expanding customization entries into actions, the engine SHALL skip any entry whose referenced variable is absent from the resolved variables dict. No action object is created for unset variables.
+
+#### Scenario: Unset variable skipped
+- **WHEN** a customization references variable `theme_color` which has no default and no value provided
+- **THEN** no action is created for that entry
+
+#### Scenario: Set variable creates action
+- **WHEN** a customization references variable `app_name` which resolves to `"Foo"`
+- **THEN** an action is created with the resolved value
+
+#### Scenario: Mixed set and unset in same customization
+- **WHEN** a customization has two replace entries, one referencing a set variable and one referencing an unset variable
+- **THEN** only the action for the set variable is created; the unset entry is skipped

--- a/src/engraft/actions/__init__.py
+++ b/src/engraft/actions/__init__.py
@@ -13,12 +13,12 @@ def register(name: str):
     return decorator
 
 
-def create_action(action_name: str, **config) -> Action:
-    """Instantiate an action by name with the given config."""
+def get_action_class(action_name: str) -> type[Action]:
+    """Look up a registered action class by name."""
     if action_name not in _REGISTRY:
         available = list(_REGISTRY.keys())
         raise ValueError(f"Unknown action: {action_name!r}. Available: {available}")
-    return _REGISTRY[action_name](**config)
+    return _REGISTRY[action_name]
 
 
 # Import action modules to trigger registration
@@ -29,4 +29,4 @@ from engraft.actions import (  # noqa: E402
     regex_replace,  # noqa: F401
 )
 
-__all__ = ["Action", "create_action", "register"]
+__all__ = ["Action", "get_action_class", "register"]

--- a/src/engraft/actions/base.py
+++ b/src/engraft/actions/base.py
@@ -1,27 +1,15 @@
 from abc import ABC, abstractmethod
-from pathlib import Path
 
 
 class Action(ABC):
-    """Base class for all customization actions."""
+    """Base class for all customization actions.
+
+    Actions are fully resolved at construction time — they hold their
+    target path, resolved value, and any other dependencies. The apply()
+    method takes no arguments.
+    """
 
     @abstractmethod
-    def apply(
-        self,
-        variables: dict[str, str],
-        work_dir: Path,
-        values_dir: Path,
-    ) -> None:
-        """Apply this action.
-
-        Args:
-            variables: Resolved variable map (name -> value).
-            work_dir: Root directory (for target file paths).
-            values_dir: Directory containing the values file.
-        """
-        ...
-
-    @abstractmethod
-    def target_files(self) -> list[str]:
-        """Return project-relative file paths this action operates on."""
+    def apply(self) -> None:
+        """Apply this action."""
         ...

--- a/src/engraft/actions/file_replace.py
+++ b/src/engraft/actions/file_replace.py
@@ -11,26 +11,14 @@ from engraft.actions.base import Action
 class FileReplace(Action):
     """Replace a file in the working directory with a source file."""
 
-    file: str
-    variable: str
+    target: Path
+    source_path: Path
 
-    def apply(
-        self,
-        variables: dict[str, str],
-        work_dir: Path,
-        values_dir: Path,
-    ) -> None:
-        source_path = values_dir / variables[self.variable]
-        target_path = work_dir / self.file
+    def apply(self) -> None:
+        if not self.source_path.exists():
+            raise FileNotFoundError(f"Source file does not exist: {self.source_path}")
 
-        if not source_path.exists():
-            raise FileNotFoundError(f"Source file does not exist: {source_path}")
+        if not self.target.exists():
+            raise FileNotFoundError(f"Target file does not exist: {self.target}")
 
-        if not target_path.exists():
-            raise FileNotFoundError(f"Target file does not exist: {target_path}")
-
-        shutil.copy2(source_path, target_path)
-
-    def target_files(self) -> list[str]:
-        """Return project-relative file paths this action operates on."""
-        return [self.file]
+        shutil.copy2(self.source_path, self.target)

--- a/src/engraft/actions/html_replace.py
+++ b/src/engraft/actions/html_replace.py
@@ -1,5 +1,5 @@
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 from lxml import html as lxml_html
@@ -18,53 +18,40 @@ def _extract_doctype(raw_html: str) -> str | None:
 @register("html_replace")
 @dataclass
 class HtmlReplace(Action):
-    """Replace values in HTML files using XPath selectors."""
+    """Replace a value in an HTML file using an XPath selector."""
 
-    file: str
-    replace: list[dict[str, str]] = field(default_factory=list)
+    target: Path
+    selector: str
+    value: str
 
-    def apply(
-        self,
-        variables: dict[str, str],
-        work_dir: Path,
-        values_dir: Path,
-    ) -> None:
-        target = work_dir / self.file
-        raw_html = target.read_text()
+    def apply(self) -> None:
+        raw_html = self.target.read_text()
         doctype = _extract_doctype(raw_html)
 
         doc = lxml_html.fromstring(raw_html)
 
-        for entry in self.replace:
-            selector = entry["selector"]
-            var_name = entry["variable"]
-            value = variables[var_name]
+        results = doc.xpath(self.selector)
 
-            results = doc.xpath(selector)
+        if len(results) == 0:
+            raise ValueError(
+                f"XPath selector {self.selector!r} matched no elements "
+                f"in {self.target.name}"
+            )
+        if len(results) > 1:
+            raise ValueError(
+                f"XPath selector {self.selector!r} matched {len(results)} elements "
+                f"in {self.target.name}, expected exactly 1"
+            )
 
-            if len(results) == 0:
-                raise ValueError(
-                    f"XPath selector {selector!r} matched no elements in {self.file}"
-                )
-            if len(results) > 1:
-                raise ValueError(
-                    f"XPath selector {selector!r} matched {len(results)} elements "
-                    f"in {self.file}, expected exactly 1"
-                )
+        result = results[0]
 
-            result = results[0]
+        if isinstance(result, _Element):
+            result.text = self.value
+        else:
+            parent = result.getparent()
+            attr_name = result.attrname
+            parent.set(attr_name, self.value)
 
-            if isinstance(result, _Element):
-                # Element node — set text content
-                result.text = value
-            else:
-                # Attribute result — lxml returns _ElementStringResult
-                # which has getparent() and attrname
-                parent = result.getparent()
-                attr_name = result.attrname
-                parent.set(attr_name, value)
-
-        # Serialize back to HTML
         output = lxml_html.tostring(doc, encoding="unicode", method="html")
 
         if doctype:
@@ -72,8 +59,4 @@ class HtmlReplace(Action):
         else:
             output = output + "\n"
 
-        target.write_text(output)
-
-    def target_files(self) -> list[str]:
-        """Return project-relative file paths this action operates on."""
-        return [self.file]
+        self.target.write_text(output)

--- a/src/engraft/actions/json_replace.py
+++ b/src/engraft/actions/json_replace.py
@@ -1,6 +1,6 @@
 import json
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 from engraft.actions import register
@@ -47,34 +47,20 @@ def _set_at_path(obj: dict | list, path: list[str | int], value: str) -> None:
 @register("json_replace")
 @dataclass
 class JsonReplace(Action):
-    """Replace values in JSON files using JSONPath-like selectors."""
+    """Replace a value in a JSON file using a JSONPath-like selector."""
 
-    file: str
-    replace: list[dict[str, str]] = field(default_factory=list)
+    target: Path
+    selector: str
+    value: str
 
-    def apply(
-        self,
-        variables: dict[str, str],
-        work_dir: Path,
-        values_dir: Path,
-    ) -> None:
-        target = work_dir / self.file
-        data = json.loads(target.read_text())
+    def apply(self) -> None:
+        data = json.loads(self.target.read_text())
 
-        for entry in self.replace:
-            selector = entry["selector"]
-            var_name = entry["variable"]
+        selector = self.selector
+        if selector.startswith("$."):
+            selector = selector[2:]
 
-            # Strip $. prefix
-            if selector.startswith("$."):
-                selector = selector[2:]
+        parsed = _parse_path(selector)
+        _set_at_path(data, parsed, self.value)
 
-            value = variables[var_name]
-            parsed = _parse_path(selector)
-            _set_at_path(data, parsed, value)
-
-        target.write_text(json.dumps(data, indent=2) + "\n")
-
-    def target_files(self) -> list[str]:
-        """Return project-relative file paths this action operates on."""
-        return [self.file]
+        self.target.write_text(json.dumps(data, indent=2) + "\n")

--- a/src/engraft/actions/regex_replace.py
+++ b/src/engraft/actions/regex_replace.py
@@ -1,5 +1,5 @@
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 from engraft.actions import register
@@ -9,48 +9,36 @@ from engraft.actions.base import Action
 @register("regex_replace")
 @dataclass
 class RegexReplace(Action):
-    """Replace values in text files using regex selectors with named capture groups."""
+    """Replace a value in a text file using a regex selector."""
 
-    file: str
-    replace: list[dict[str, str]] = field(default_factory=list)
+    target: Path
+    selector: str
+    value: str
 
-    def apply(
-        self,
-        variables: dict[str, str],
-        work_dir: Path,
-        values_dir: Path,
-    ) -> None:
-        target = work_dir / self.file
-        content = target.read_text()
+    def apply(self) -> None:
+        content = self.target.read_text()
 
-        for entry in self.replace:
-            pattern = entry["selector"]
-            var_name = entry["variable"]
+        if "(?P<value>" not in self.selector:
+            raise ValueError(
+                f"Pattern must contain a (?P<value>...) named group: {self.selector!r}"
+            )
 
-            if "(?P<value>" not in pattern:
-                raise ValueError(
-                    f"Pattern must contain a (?P<value>...) named group: {pattern!r}"
-                )
+        compiled = re.compile(self.selector)
 
-            new_value = variables[var_name]
-            compiled = re.compile(pattern)
+        if not compiled.search(content):
+            raise ValueError(
+                f"Pattern {self.selector!r} did not match "
+                f"anything in {self.target.name}"
+            )
 
-            if not compiled.search(content):
-                raise ValueError(
-                    f"Pattern {pattern!r} did not match anything in {self.file}"
-                )
+        new_value = self.value
 
-            def replacer(match: re.Match, new_val: str = new_value) -> str:
-                start, end = match.span("value")
-                full_start = match.start()
-                prefix = match.group()[: start - full_start]
-                suffix = match.group()[end - full_start :]
-                return prefix + new_val + suffix
+        def replacer(match: re.Match, new_val: str = new_value) -> str:
+            start, end = match.span("value")
+            full_start = match.start()
+            prefix = match.group()[: start - full_start]
+            suffix = match.group()[end - full_start :]
+            return prefix + new_val + suffix
 
-            content = compiled.sub(replacer, content)
-
-        target.write_text(content)
-
-    def target_files(self) -> list[str]:
-        """Return project-relative file paths this action operates on."""
-        return [self.file]
+        content = compiled.sub(replacer, content)
+        self.target.write_text(content)

--- a/src/engraft/engine.py
+++ b/src/engraft/engine.py
@@ -1,9 +1,81 @@
 import shutil
 from pathlib import Path
 
-from engraft.models import parse_template, parse_values
+from engraft.actions import Action, get_action_class
+from engraft.actions.file_replace import FileReplace
+from engraft.models import Template, parse_template, parse_values
 
 STAGING_DIR_NAME = ".engraft"
+
+
+def resolve_variables(template: Template, values: dict[str, str]) -> dict[str, str]:
+    """Merge template defaults with provided values.
+
+    Returns a dict containing only variables that have a resolved value
+    (either from values or from a default). Variables with no default
+    and no provided value are omitted.
+    """
+    resolved: dict[str, str] = {}
+    for var in template.variables:
+        if var.name in values:
+            resolved[var.name] = values[var.name]
+        elif var.default is not None:
+            resolved[var.name] = var.default
+    return resolved
+
+
+def _collect_target_files(customizations: list[dict]) -> set[str]:
+    """Extract deduplicated target file paths from raw customization entries."""
+    targets: set[str] = set()
+    for entry in customizations:
+        file_path = entry.get("file")
+        if file_path:
+            targets.add(file_path)
+    return targets
+
+
+def _build_actions(
+    customizations: list[dict],
+    variables: dict[str, str],
+    staging_dir: Path,
+    values_dir: Path,
+) -> list[Action]:
+    """Expand raw customization entries into fully resolved Action objects.
+
+    Multi-entry replace lists are expanded into individual actions.
+    Entries referencing unset variables are skipped.
+    """
+    actions: list[Action] = []
+
+    for entry in customizations:
+        action_name = entry["action"]
+        file_path = entry["file"]
+        target = staging_dir / file_path
+
+        # Validate action name
+        action_cls = get_action_class(action_name)
+
+        if action_cls is FileReplace:
+            var_name = entry["variable"]
+            if var_name not in variables:
+                continue
+            source_path = values_dir / variables[var_name]
+            actions.append(FileReplace(target=target, source_path=source_path))
+        else:
+            # Actions with replace lists (json_replace, regex_replace, html_replace)
+            for replace_entry in entry.get("replace", []):
+                var_name = replace_entry["variable"]
+                if var_name not in variables:
+                    continue
+                actions.append(
+                    action_cls(
+                        target=target,
+                        selector=replace_entry["selector"],
+                        value=variables[var_name],
+                    )
+                )
+
+    return actions
 
 
 def apply(
@@ -30,25 +102,20 @@ def apply(
     template = parse_template(template_path)
     values = parse_values(values_path)
 
-    # Resolve variables: values override defaults
-    variables: dict[str, str] = {}
-    for name, var in template.variables.items():
-        variables[name] = values.get(name, var.default)
+    # Step 1: Resolve variables (only set ones)
+    variables = resolve_variables(template, values)
 
+    # Step 2: Collect target files from raw customization entries
+    target_files = _collect_target_files(template.customizations)
+
+    # Step 3: Create staging directory
     staging_dir = work_dir / STAGING_DIR_NAME
-
-    # Step 1: Collect target files from all actions
-    target_files: set[str] = set()
-    for action in template.customizations:
-        target_files.update(action.target_files())
-
-    # Step 2: Create staging directory (remove if exists)
     if staging_dir.exists():
         shutil.rmtree(staging_dir)
     staging_dir.mkdir()
 
     try:
-        # Copy target files into staging directory
+        # Step 4: Copy target files into staging directory
         for rel_path in target_files:
             src = work_dir / rel_path
             dst = staging_dir / rel_path
@@ -56,11 +123,16 @@ def apply(
                 dst.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(src, dst)
 
-        # Step 3: Execute all actions against the staging directory
-        for action in template.customizations:
-            action.apply(variables, staging_dir, values_dir)
+        # Step 5: Build fully resolved actions (skipping unset variables)
+        actions = _build_actions(
+            template.customizations, variables, staging_dir, values_dir
+        )
 
-        # Step 4: Copy back all files from staging to work directory
+        # Step 6: Execute all actions
+        for action in actions:
+            action.apply()
+
+        # Step 7: Copy back all files from staging to work directory
         for staged_file in staging_dir.rglob("*"):
             if staged_file.is_file():
                 rel_path = staged_file.relative_to(staging_dir)
@@ -68,5 +140,5 @@ def apply(
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(staged_file, dest)
     finally:
-        # Step 5: Always remove staging directory
+        # Always remove staging directory
         shutil.rmtree(staging_dir, ignore_errors=True)

--- a/src/engraft/models.py
+++ b/src/engraft/models.py
@@ -3,39 +3,51 @@ from pathlib import Path
 
 import yaml
 
-from engraft.actions import Action, create_action
-
 
 @dataclass
 class Variable:
+    """A template variable definition."""
+
     name: str
     description: str
-    default: str
+    default: str | None = None
 
 
 @dataclass
 class Template:
-    variables: dict[str, Variable]
-    customizations: list[Action]
+    """Parsed template with variable definitions and raw customization entries."""
+
+    variables: list[Variable]
+    customizations: list[dict]
 
 
 def parse_template(path: Path) -> Template:
-    """Load a template YAML file into a Template model."""
+    """Load a template YAML file into a Template model.
+
+    Variables are parsed from array format. Customization entries are
+    stored as raw dicts for later expansion by the engine.
+    """
     with open(path) as f:
         data = yaml.safe_load(f)
 
-    variables: dict[str, Variable] = {}
-    for name, var_data in (data.get("variables") or {}).items():
-        variables[name] = Variable(
-            name=name,
-            description=var_data.get("description", ""),
-            default=var_data.get("default", ""),
+    variables: list[Variable] = []
+    seen_names: set[str] = set()
+    for var_data in data.get("variables") or []:
+        name = var_data["variable"]
+        if name in seen_names:
+            raise ValueError(f"Duplicate variable name: {name!r}")
+        seen_names.add(name)
+        variables.append(
+            Variable(
+                name=name,
+                description=var_data.get("description", ""),
+                default=var_data.get("default"),
+            )
         )
 
-    customizations: list[Action] = []
+    customizations: list[dict] = []
     for item in data.get("customizations") or []:
-        action_name = item.pop("action")
-        customizations.append(create_action(action_name, **item))
+        customizations.append(dict(item))
 
     return Template(variables=variables, customizations=customizations)
 

--- a/tests/test_actions/test_file_replace.py
+++ b/tests/test_actions/test_file_replace.py
@@ -3,56 +3,47 @@ import pytest
 from engraft.actions.file_replace import FileReplace
 
 
-@pytest.fixture
-def work_dir(tmp_path):
-    project = tmp_path / "project"
-    project.mkdir()
-    return project
-
-
-@pytest.fixture
-def values_dir(tmp_path):
-    vd = tmp_path / "values"
-    vd.mkdir()
-    return vd
-
-
-def test_basic_replacement(work_dir, values_dir):
-    target = work_dir / "logo.png"
+def test_basic_replacement(tmp_path):
+    target = tmp_path / "logo.png"
     target.write_text("old logo")
 
-    source = values_dir / "my_logo.png"
+    source = tmp_path / "values" / "my_logo.png"
+    source.parent.mkdir()
     source.write_text("new logo")
 
-    action = FileReplace(file="logo.png", variable="logo_path")
-    action.apply({"logo_path": "my_logo.png"}, work_dir, values_dir)
+    action = FileReplace(target=target, source_path=source)
+    action.apply()
 
     assert target.read_text() == "new logo"
 
 
-def test_binary_file(work_dir, values_dir):
-    target = work_dir / "icon.png"
+def test_binary_file(tmp_path):
+    target = tmp_path / "icon.png"
     target.write_bytes(b"\x89PNG old")
 
-    source = values_dir / "new_icon.png"
+    source = tmp_path / "values" / "new_icon.png"
+    source.parent.mkdir()
     source.write_bytes(b"\x89PNG new")
 
-    action = FileReplace(file="icon.png", variable="icon_path")
-    action.apply({"icon_path": "new_icon.png"}, work_dir, values_dir)
+    action = FileReplace(target=target, source_path=source)
+    action.apply()
 
     assert target.read_bytes() == b"\x89PNG new"
 
 
-def test_error_source_missing(work_dir, values_dir):
-    action = FileReplace(file="logo.png", variable="logo_path")
+def test_error_source_missing(tmp_path):
+    target = tmp_path / "logo.png"
+    target.write_text("existing")
+
+    action = FileReplace(target=target, source_path=tmp_path / "nonexistent.png")
     with pytest.raises(FileNotFoundError):
-        action.apply({"logo_path": "nonexistent.png"}, work_dir, values_dir)
+        action.apply()
 
 
-def test_error_target_missing(work_dir, values_dir):
-    source = values_dir / "img.png"
+def test_error_target_missing(tmp_path):
+    source = tmp_path / "img.png"
     source.write_text("image data")
 
-    action = FileReplace(file="assets/images/logo.png", variable="img_path")
+    action = FileReplace(target=tmp_path / "missing.png", source_path=source)
     with pytest.raises(FileNotFoundError):
-        action.apply({"img_path": "img.png"}, work_dir, values_dir)
+        action.apply()

--- a/tests/test_actions/test_html_replace.py
+++ b/tests/test_actions/test_html_replace.py
@@ -20,141 +20,81 @@ SAMPLE_HTML = """\
 </html>"""
 
 
-@pytest.fixture
-def work_dir(tmp_path):
-    return tmp_path
-
-
-@pytest.fixture
-def values_dir(tmp_path):
-    return tmp_path / "values"
-
-
-def test_set_element_text(work_dir, values_dir):
-    f = work_dir / "index.html"
+def test_set_element_text(tmp_path):
+    f = tmp_path / "index.html"
     f.write_text(SAMPLE_HTML)
 
-    action = HtmlReplace(
-        file="index.html",
-        replace=[
-            {"selector": "//title", "variable": "my_title"},
-        ],
-    )
-    action.apply({"my_title": "New Title"}, work_dir, values_dir)
+    action = HtmlReplace(target=f, selector="//title", value="New Title")
+    action.apply()
 
     content = f.read_text()
     assert "<title>New Title</title>" in content
     assert "Animals Audioguide" not in content
 
 
-def test_set_attribute(work_dir, values_dir):
-    f = work_dir / "index.html"
+def test_set_attribute(tmp_path):
+    f = tmp_path / "index.html"
     f.write_text(SAMPLE_HTML)
 
     action = HtmlReplace(
-        file="index.html",
-        replace=[
-            {"selector": '//meta[@name="Description"]/@content', "variable": "desc"},
-        ],
+        target=f,
+        selector='//meta[@name="Description"]/@content',
+        value="My new description",
     )
-    action.apply({"desc": "My new description"}, work_dir, values_dir)
+    action.apply()
 
     content = f.read_text()
     assert 'content="My new description"' in content
     assert "A sample audioguide app" not in content
 
 
-def test_set_html_lang_attribute(work_dir, values_dir):
-    f = work_dir / "index.html"
+def test_set_html_lang_attribute(tmp_path):
+    f = tmp_path / "index.html"
     f.write_text(SAMPLE_HTML)
 
-    action = HtmlReplace(
-        file="index.html",
-        replace=[
-            {"selector": "//html/@lang", "variable": "lang"},
-        ],
-    )
-    action.apply({"lang": "de"}, work_dir, values_dir)
+    action = HtmlReplace(target=f, selector="//html/@lang", value="de")
+    action.apply()
 
     content = f.read_text()
     assert 'lang="de"' in content
 
 
-def test_multiple_replacements(work_dir, values_dir):
-    f = work_dir / "index.html"
+def test_error_no_match(tmp_path):
+    f = tmp_path / "index.html"
     f.write_text(SAMPLE_HTML)
 
-    action = HtmlReplace(
-        file="index.html",
-        replace=[
-            {"selector": "//title", "variable": "my_title"},
-            {"selector": '//meta[@name="Description"]/@content', "variable": "desc"},
-        ],
-    )
-    action.apply({"my_title": "New Title", "desc": "New desc"}, work_dir, values_dir)
-
-    content = f.read_text()
-    assert "<title>New Title</title>" in content
-    assert 'content="New desc"' in content
-
-
-def test_error_no_match(work_dir, values_dir):
-    f = work_dir / "index.html"
-    f.write_text(SAMPLE_HTML)
-
-    action = HtmlReplace(
-        file="index.html",
-        replace=[
-            {"selector": "//nonexistent", "variable": "val"},
-        ],
-    )
+    action = HtmlReplace(target=f, selector="//nonexistent", value="x")
     with pytest.raises(ValueError, match="matched no elements"):
-        action.apply({"val": "x"}, work_dir, values_dir)
+        action.apply()
 
 
-def test_error_multiple_matches(work_dir, values_dir):
-    f = work_dir / "index.html"
+def test_error_multiple_matches(tmp_path):
+    f = tmp_path / "index.html"
     f.write_text(SAMPLE_HTML)
 
-    action = HtmlReplace(
-        file="index.html",
-        replace=[
-            {"selector": "//p", "variable": "val"},
-        ],
-    )
+    action = HtmlReplace(target=f, selector="//p", value="x")
     with pytest.raises(ValueError, match="matched 3 elements.*expected exactly 1"):
-        action.apply({"val": "x"}, work_dir, values_dir)
+        action.apply()
 
 
-def test_doctype_preserved(work_dir, values_dir):
-    f = work_dir / "index.html"
+def test_doctype_preserved(tmp_path):
+    f = tmp_path / "index.html"
     f.write_text(SAMPLE_HTML)
 
-    action = HtmlReplace(
-        file="index.html",
-        replace=[
-            {"selector": "//title", "variable": "my_title"},
-        ],
-    )
-    action.apply({"my_title": "Test"}, work_dir, values_dir)
+    action = HtmlReplace(target=f, selector="//title", value="Test")
+    action.apply()
 
     content = f.read_text()
     assert content.startswith("<!DOCTYPE html>")
 
 
-def test_void_elements_not_self_closed(work_dir, values_dir):
-    f = work_dir / "index.html"
+def test_void_elements_not_self_closed(tmp_path):
+    f = tmp_path / "index.html"
     f.write_text(SAMPLE_HTML)
 
-    action = HtmlReplace(
-        file="index.html",
-        replace=[
-            {"selector": "//title", "variable": "my_title"},
-        ],
-    )
-    action.apply({"my_title": "Test"}, work_dir, values_dir)
+    action = HtmlReplace(target=f, selector="//title", value="Test")
+    action.apply()
 
     content = f.read_text()
-    # meta tags should NOT be self-closed in HTML output
     assert "<meta " in content
     assert "/>" not in content or "<meta" not in content.split("/>")[0]

--- a/tests/test_actions/test_json_replace.py
+++ b/tests/test_actions/test_json_replace.py
@@ -1,18 +1,6 @@
 import json
 
-import pytest
-
 from engraft.actions.json_replace import JsonReplace
-
-
-@pytest.fixture
-def work_dir(tmp_path):
-    return tmp_path
-
-
-@pytest.fixture
-def values_dir(tmp_path):
-    return tmp_path / "values"
 
 
 def _write_json(path, data):
@@ -23,98 +11,55 @@ def _read_json(path):
     return json.loads(path.read_text())
 
 
-def test_simple_path(work_dir, values_dir):
-    f = work_dir / "app.json"
+def test_simple_path(tmp_path):
+    f = tmp_path / "app.json"
     _write_json(f, {"name": "old"})
 
-    action = JsonReplace(
-        file="app.json",
-        replace=[
-            {"selector": "$.name", "variable": "app_name"},
-        ],
-    )
-    action.apply({"app_name": "MyApp"}, work_dir, values_dir)
+    action = JsonReplace(target=f, selector="$.name", value="MyApp")
+    action.apply()
 
     assert _read_json(f)["name"] == "MyApp"
 
 
-def test_nested_path(work_dir, values_dir):
-    f = work_dir / "app.json"
+def test_nested_path(tmp_path):
+    f = tmp_path / "app.json"
     _write_json(f, {"expo": {"name": "old", "version": "1.0"}})
 
-    action = JsonReplace(
-        file="app.json",
-        replace=[
-            {"selector": "$.expo.name", "variable": "app_name"},
-        ],
-    )
-    action.apply({"app_name": "NewApp"}, work_dir, values_dir)
+    action = JsonReplace(target=f, selector="$.expo.name", value="NewApp")
+    action.apply()
 
     data = _read_json(f)
     assert data["expo"]["name"] == "NewApp"
     assert data["expo"]["version"] == "1.0"
 
 
-def test_array_index(work_dir, values_dir):
-    f = work_dir / "app.json"
+def test_array_index(tmp_path):
+    f = tmp_path / "app.json"
     _write_json(f, {"items": [{"label": "first"}, {"label": "second"}]})
 
-    action = JsonReplace(
-        file="app.json",
-        replace=[
-            {"selector": "$.items[0].label", "variable": "lbl"},
-        ],
-    )
-    action.apply({"lbl": "updated"}, work_dir, values_dir)
+    action = JsonReplace(target=f, selector="$.items[0].label", value="updated")
+    action.apply()
 
     assert _read_json(f)["items"][0]["label"] == "updated"
     assert _read_json(f)["items"][1]["label"] == "second"
 
 
-def test_missing_intermediate_key(work_dir, values_dir):
-    f = work_dir / "app.json"
+def test_missing_intermediate_key(tmp_path):
+    f = tmp_path / "app.json"
     _write_json(f, {})
 
-    action = JsonReplace(
-        file="app.json",
-        replace=[
-            {"selector": "$.a.b.c", "variable": "val"},
-        ],
-    )
-    action.apply({"val": "deep"}, work_dir, values_dir)
+    action = JsonReplace(target=f, selector="$.a.b.c", value="deep")
+    action.apply()
 
     assert _read_json(f)["a"]["b"]["c"] == "deep"
 
 
-def test_multiple_replacements(work_dir, values_dir):
-    f = work_dir / "app.json"
-    _write_json(f, {"name": "old", "version": "0.0"})
-
-    action = JsonReplace(
-        file="app.json",
-        replace=[
-            {"selector": "$.name", "variable": "app_name"},
-            {"selector": "$.version", "variable": "app_version"},
-        ],
-    )
-    action.apply({"app_name": "MyApp", "app_version": "1.0"}, work_dir, values_dir)
-
-    data = _read_json(f)
-    assert data["name"] == "MyApp"
-    assert data["version"] == "1.0"
-
-
-def test_preserves_formatting(work_dir, values_dir):
-    f = work_dir / "app.json"
+def test_preserves_formatting(tmp_path):
+    f = tmp_path / "app.json"
     _write_json(f, {"key": "val"})
 
-    action = JsonReplace(
-        file="app.json",
-        replace=[
-            {"selector": "$.key", "variable": "v"},
-        ],
-    )
-    action.apply({"v": "new"}, work_dir, values_dir)
+    action = JsonReplace(target=f, selector="$.key", value="new")
+    action.apply()
 
     content = f.read_text()
     assert content.startswith("{\n")

--- a/tests/test_actions/test_regex_replace.py
+++ b/tests/test_actions/test_regex_replace.py
@@ -3,126 +3,76 @@ import pytest
 from engraft.actions.regex_replace import RegexReplace
 
 
-@pytest.fixture
-def work_dir(tmp_path):
-    return tmp_path
-
-
-@pytest.fixture
-def values_dir(tmp_path):
-    return tmp_path / "values"
-
-
-def test_basic_replacement(work_dir, values_dir):
-    ts_file = work_dir / "colors.ts"
+def test_basic_replacement(tmp_path):
+    ts_file = tmp_path / "colors.ts"
     ts_file.write_text('export const PRIMARY_COLOR = "#ff0000";\n')
 
     action = RegexReplace(
-        file="colors.ts",
-        replace=[
-            {
-                "selector": r'(PRIMARY_COLOR\s*=\s*)"(?P<value>[^"]*)"',
-                "variable": "primary_color",
-            },
-        ],
+        target=ts_file,
+        selector=r'(PRIMARY_COLOR\s*=\s*)"(?P<value>[^"]*)"',
+        value="#00ff00",
     )
-    action.apply({"primary_color": "#00ff00"}, work_dir, values_dir)
+    action.apply()
 
     assert "#00ff00" in ts_file.read_text()
     assert "#ff0000" not in ts_file.read_text()
 
 
-def test_multiple_replacements(work_dir, values_dir):
-    ts_file = work_dir / "colors.ts"
-    ts_file.write_text(
-        'export const PRIMARY_COLOR = "#ff0000";\n'
-        'export const SECONDARY_COLOR = "#00ff00";\n'
-    )
-
-    action = RegexReplace(
-        file="colors.ts",
-        replace=[
-            {
-                "selector": r'(PRIMARY_COLOR\s*=\s*)"(?P<value>[^"]*)"',
-                "variable": "primary",
-            },
-            {
-                "selector": r'(SECONDARY_COLOR\s*=\s*)"(?P<value>[^"]*)"',
-                "variable": "secondary",
-            },
-        ],
-    )
-    action.apply({"primary": "#111111", "secondary": "#222222"}, work_dir, values_dir)
-
-    content = ts_file.read_text()
-    assert "#111111" in content
-    assert "#222222" in content
-    assert "#ff0000" not in content
-    assert "#00ff00" not in content
-
-
-def test_multiple_matches_in_file(work_dir, values_dir):
-    ts_file = work_dir / "config.ts"
+def test_multiple_matches_in_file(tmp_path):
+    ts_file = tmp_path / "config.ts"
     ts_file.write_text('const A = "old_value";\nconst B = "old_value";\n')
 
     action = RegexReplace(
-        file="config.ts",
-        replace=[
-            {"selector": r'"(?P<value>old_value)"', "variable": "val"},
-        ],
+        target=ts_file,
+        selector=r'"(?P<value>old_value)"',
+        value="new_value",
     )
-    action.apply({"val": "new_value"}, work_dir, values_dir)
+    action.apply()
 
     content = ts_file.read_text()
     assert content.count('"new_value"') == 2
     assert "old_value" not in content
 
 
-def test_reapplication(work_dir, values_dir):
-    ts_file = work_dir / "colors.ts"
+def test_reapplication(tmp_path):
+    ts_file = tmp_path / "colors.ts"
     ts_file.write_text('export const PRIMARY_COLOR = "#ff0000";\n')
 
     action = RegexReplace(
-        file="colors.ts",
-        replace=[
-            {
-                "selector": r'(PRIMARY_COLOR\s*=\s*)"(?P<value>[^"]*)"',
-                "variable": "primary_color",
-            },
-        ],
+        target=ts_file,
+        selector=r'(PRIMARY_COLOR\s*=\s*)"(?P<value>[^"]*)"',
+        value="#00ff00",
     )
-
-    action.apply({"primary_color": "#00ff00"}, work_dir, values_dir)
+    action.apply()
     assert "#00ff00" in ts_file.read_text()
 
-    action.apply({"primary_color": "#0000ff"}, work_dir, values_dir)
+    action2 = RegexReplace(
+        target=ts_file,
+        selector=r'(PRIMARY_COLOR\s*=\s*)"(?P<value>[^"]*)"',
+        value="#0000ff",
+    )
+    action2.apply()
     assert "#0000ff" in ts_file.read_text()
     assert "#00ff00" not in ts_file.read_text()
 
 
-def test_error_no_value_group(work_dir, values_dir):
-    ts_file = work_dir / "test.ts"
+def test_error_no_value_group(tmp_path):
+    ts_file = tmp_path / "test.ts"
     ts_file.write_text("hello")
 
-    action = RegexReplace(
-        file="test.ts",
-        replace=[
-            {"selector": r"hello", "variable": "val"},
-        ],
-    )
+    action = RegexReplace(target=ts_file, selector=r"hello", value="world")
     with pytest.raises(ValueError, match="named group"):
-        action.apply({"val": "world"}, work_dir, values_dir)
+        action.apply()
 
 
-def test_error_no_match(work_dir, values_dir):
-    ts_file = work_dir / "test.ts"
+def test_error_no_match(tmp_path):
+    ts_file = tmp_path / "test.ts"
     ts_file.write_text("hello world")
 
     action = RegexReplace(
-        file="test.ts",
-        replace=[
-            {"selector": r'NONEXISTENT\s*=\s*"(?P<value>[^"]*)"', "variable": "val"},
-        ],
+        target=ts_file,
+        selector=r'NONEXISTENT\s*=\s*"(?P<value>[^"]*)"',
+        value="x",
     )
     with pytest.raises(ValueError, match="did not match"):
-        action.apply({"val": "x"}, work_dir, values_dir)
+        action.apply()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,9 +17,13 @@ def _setup_project(tmp_path):
     template.write_text(
         yaml.dump(
             {
-                "variables": {
-                    "app_name": {"description": "App name", "default": "default"},
-                },
+                "variables": [
+                    {
+                        "variable": "app_name",
+                        "description": "App name",
+                        "default": "default",
+                    },
+                ],
                 "customizations": [
                     {
                         "action": "json_replace",
@@ -74,7 +78,7 @@ def test_apply_missing_template(tmp_path):
 
 def test_apply_missing_values(tmp_path):
     template = tmp_path / "template.yml"
-    template.write_text(yaml.dump({"variables": {}, "customizations": []}))
+    template.write_text(yaml.dump({"variables": [], "customizations": []}))
 
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -12,7 +12,6 @@ def project(tmp_path):
     project_dir = tmp_path / "project"
     project_dir.mkdir()
 
-    # JSON file
     (project_dir / "app.json").write_text(
         json.dumps(
             {
@@ -32,14 +31,12 @@ def project(tmp_path):
         + "\n"
     )
 
-    # TS file
     (project_dir / "src").mkdir()
     (project_dir / "src" / "theme.ts").write_text(
         'export const PRIMARY_COLOR = "#ff0000";\n'
         'export const APP_TITLE = "Default App";\n'
     )
 
-    # Image file
     (project_dir / "assets").mkdir()
     (project_dir / "assets" / "logo.png").write_bytes(b"\x89PNG default logo data")
 
@@ -52,23 +49,38 @@ def template_file(tmp_path):
     t.write_text(
         yaml.dump(
             {
-                "variables": {
-                    "app_name": {
+                "variables": [
+                    {
+                        "variable": "app_name",
                         "description": "Application name",
                         "default": "DefaultApp",
                     },
-                    "app_slug": {"description": "URL slug", "default": "default-app"},
-                    "primary_color": {
+                    {
+                        "variable": "app_slug",
+                        "description": "URL slug",
+                        "default": "default-app",
+                    },
+                    {
+                        "variable": "primary_color",
                         "description": "Primary color hex",
                         "default": "#ff0000",
                     },
-                    "app_title": {"description": "App title", "default": "Default App"},
-                    "item_one_label": {
+                    {
+                        "variable": "app_title",
+                        "description": "App title",
+                        "default": "Default App",
+                    },
+                    {
+                        "variable": "item_one_label",
                         "description": "First item label",
                         "default": "Item One",
                     },
-                    "logo": {"description": "Path to logo file", "default": "logo.png"},
-                },
+                    {
+                        "variable": "logo",
+                        "description": "Path to logo file",
+                        "default": "logo.png",
+                    },
+                ],
                 "customizations": [
                     {
                         "action": "json_replace",
@@ -122,7 +134,6 @@ def _make_values(values_dir, overrides):
 
 
 def test_full_apply(project, template_file, values_dir):
-    # Set up custom logo
     (values_dir / "custom_logo.png").write_bytes(b"\x89PNG custom logo")
 
     values_file = _make_values(
@@ -139,20 +150,17 @@ def test_full_apply(project, template_file, values_dir):
 
     apply(template_file, values_file, work_dir=project)
 
-    # Check JSON
     app_json = json.loads((project / "app.json").read_text())
     assert app_json["expo"]["name"] == "MyApp"
     assert app_json["expo"]["slug"] == "my-app"
     assert app_json["expo"]["extra"]["items"][0]["label"] == "Custom Item"
     assert app_json["expo"]["extra"]["items"][1]["label"] == "Item Two"
 
-    # Check TS
     theme = (project / "src" / "theme.ts").read_text()
     assert "#00ff00" in theme
     assert "My Application" in theme
     assert "#ff0000" not in theme
 
-    # Check logo
     assert (project / "assets" / "logo.png").read_bytes() == b"\x89PNG custom logo"
 
 
@@ -160,7 +168,6 @@ def test_reapplication(project, template_file, values_dir):
     (values_dir / "logo1.png").write_bytes(b"logo1")
     (values_dir / "logo2.png").write_bytes(b"logo2")
 
-    # First apply
     v1 = _make_values(
         values_dir,
         {
@@ -177,7 +184,6 @@ def test_reapplication(project, template_file, values_dir):
     theme = (project / "src" / "theme.ts").read_text()
     assert "#111111" in theme
 
-    # Second apply with different values
     v2 = _make_values(
         values_dir,
         {
@@ -191,7 +197,6 @@ def test_reapplication(project, template_file, values_dir):
     )
     apply(template_file, v2, work_dir=project)
 
-    # Verify second apply took effect
     app_json = json.loads((project / "app.json").read_text())
     assert app_json["expo"]["name"] == "App2"
 
@@ -201,3 +206,55 @@ def test_reapplication(project, template_file, values_dir):
     assert "Title Two" in theme
 
     assert (project / "assets" / "logo.png").read_bytes() == b"logo2"
+
+
+def test_partial_apply_with_unset_variables(project, values_dir, tmp_path):
+    """Only set variables are applied; unset ones are noops."""
+    template = tmp_path / "template.yml"
+    template.write_text(
+        yaml.dump(
+            {
+                "variables": [
+                    {
+                        "variable": "app_name",
+                        "description": "Application name",
+                    },
+                    {
+                        "variable": "primary_color",
+                        "description": "Primary color hex",
+                    },
+                ],
+                "customizations": [
+                    {
+                        "action": "json_replace",
+                        "file": "app.json",
+                        "replace": [
+                            {"selector": "$.expo.name", "variable": "app_name"},
+                        ],
+                    },
+                    {
+                        "action": "regex_replace",
+                        "file": "src/theme.ts",
+                        "replace": [
+                            {
+                                "selector": r'(PRIMARY_COLOR\s*=\s*)"(?P<value>[^"]*)"',
+                                "variable": "primary_color",
+                            },
+                        ],
+                    },
+                ],
+            }
+        )
+    )
+
+    # Only provide app_name, not primary_color
+    values_file = _make_values(values_dir, {"app_name": "PartialApp"})
+
+    apply(template, values_file, work_dir=project)
+
+    app_json = json.loads((project / "app.json").read_text())
+    assert app_json["expo"]["name"] == "PartialApp"
+
+    # Theme should be unchanged since primary_color was unset
+    theme = (project / "src" / "theme.ts").read_text()
+    assert "#ff0000" in theme

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3,11 +3,25 @@ import json
 import pytest
 import yaml
 
-from engraft.actions.file_replace import FileReplace
-from engraft.actions.html_replace import HtmlReplace
-from engraft.actions.json_replace import JsonReplace
-from engraft.actions.regex_replace import RegexReplace
-from engraft.engine import STAGING_DIR_NAME, apply
+from engraft.engine import STAGING_DIR_NAME, apply, resolve_variables
+from engraft.models import Template, Variable
+
+
+def _make_template(tmp_path, customizations, variables=None):
+    """Write a template YAML and return its path."""
+    if variables is None:
+        variables = [
+            {"variable": "app_name", "description": "Name", "default": "original"},
+        ]
+    t = tmp_path / "template.yml"
+    t.write_text(yaml.dump({"variables": variables, "customizations": customizations}))
+    return t
+
+
+def _make_values(values_dir, overrides):
+    vf = values_dir / "values.yml"
+    vf.write_text(yaml.dump(overrides))
+    return vf
 
 
 @pytest.fixture
@@ -15,7 +29,6 @@ def project(tmp_path):
     """Create a minimal project with a JSON file and a text file."""
     project_dir = tmp_path / "project"
     project_dir.mkdir()
-
     (project_dir / "config.json").write_text(
         json.dumps({"name": "original"}, indent=2) + "\n"
     )
@@ -31,28 +44,53 @@ def values_dir(tmp_path):
     return vd
 
 
-def _make_template(tmp_path, customizations, variables=None):
-    """Write a template YAML and return its path."""
-    if variables is None:
-        variables = {
-            "app_name": {"description": "Name", "default": "original"},
-        }
-    t = tmp_path / "template.yml"
-    t.write_text(
-        yaml.dump(
-            {
-                "variables": variables,
-                "customizations": customizations,
-            }
+class TestResolveVariables:
+    """Test variable resolution logic."""
+
+    def test_value_overrides_default(self):
+        template = Template(
+            variables=[Variable(name="x", description="", default="default_val")],
+            customizations=[],
         )
-    )
-    return t
+        result = resolve_variables(template, {"x": "override"})
+        assert result == {"x": "override"}
 
+    def test_default_used_when_no_value(self):
+        template = Template(
+            variables=[Variable(name="x", description="", default="default_val")],
+            customizations=[],
+        )
+        result = resolve_variables(template, {})
+        assert result == {"x": "default_val"}
 
-def _make_values(values_dir, overrides):
-    vf = values_dir / "values.yml"
-    vf.write_text(yaml.dump(overrides))
-    return vf
+    def test_unset_variable_omitted(self):
+        template = Template(
+            variables=[Variable(name="x", description="", default=None)],
+            customizations=[],
+        )
+        result = resolve_variables(template, {})
+        assert "x" not in result
+
+    def test_unset_variable_with_value_included(self):
+        template = Template(
+            variables=[Variable(name="x", description="", default=None)],
+            customizations=[],
+        )
+        result = resolve_variables(template, {"x": "provided"})
+        assert result == {"x": "provided"}
+
+    def test_mixed_set_and_unset(self):
+        template = Template(
+            variables=[
+                Variable(name="a", description="", default="default_a"),
+                Variable(name="b", description="", default=None),
+                Variable(name="c", description="", default=None),
+            ],
+            customizations=[],
+        )
+        result = resolve_variables(template, {"c": "val_c"})
+        assert result == {"a": "default_a", "c": "val_c"}
+        assert "b" not in result
 
 
 class TestStagingDirectorySuccess:
@@ -100,16 +138,13 @@ class TestStagingDirectoryRollback:
     def test_failed_action_preserves_original_files(
         self, tmp_path, project, values_dir
     ):
-        """When second action fails, first action's changes are rolled back."""
         template = _make_template(
             tmp_path,
             [
                 {
                     "action": "json_replace",
                     "file": "config.json",
-                    "replace": [
-                        {"selector": "$.name", "variable": "app_name"},
-                    ],
+                    "replace": [{"selector": "$.name", "variable": "app_name"}],
                 },
                 {
                     "action": "regex_replace",
@@ -122,16 +157,15 @@ class TestStagingDirectoryRollback:
                     ],
                 },
             ],
-            variables={
-                "app_name": {"description": "Name", "default": "original"},
-            },
+            variables=[
+                {"variable": "app_name", "description": "Name", "default": "original"},
+            ],
         )
         values = _make_values(values_dir, {"app_name": "NewApp"})
 
         with pytest.raises(ValueError):
             apply(template, values, work_dir=project)
 
-        # Original files should be untouched
         data = json.loads((project / "config.json").read_text())
         assert data["name"] == "original"
 
@@ -166,7 +200,6 @@ class TestStagingDirectoryPreexisting:
     """Test that a pre-existing .engraft/ directory is handled."""
 
     def test_preexisting_staging_dir_is_removed(self, tmp_path, project, values_dir):
-        # Create a leftover .engraft/ directory
         leftover = project / STAGING_DIR_NAME
         leftover.mkdir()
         (leftover / "stale.txt").write_text("leftover")
@@ -190,21 +223,77 @@ class TestStagingDirectoryPreexisting:
         assert not (project / STAGING_DIR_NAME).exists()
 
 
-class TestTargetFiles:
-    """Test that target_files() returns correct paths for each action type."""
+class TestUnsetVariableNoop:
+    """Test that unset variables result in skipped actions."""
 
-    def test_json_replace_target_files(self):
-        action = JsonReplace(file="config.json", replace=[])
-        assert action.target_files() == ["config.json"]
+    def test_unset_variable_skips_action(self, tmp_path, project, values_dir):
+        """An action referencing an unset variable is not executed."""
+        template = _make_template(
+            tmp_path,
+            [
+                {
+                    "action": "json_replace",
+                    "file": "config.json",
+                    "replace": [{"selector": "$.name", "variable": "theme_color"}],
+                },
+            ],
+            variables=[
+                {"variable": "theme_color", "description": "Color"},
+            ],
+        )
+        values = _make_values(values_dir, {})
 
-    def test_regex_replace_target_files(self):
-        action = RegexReplace(file="src/theme.ts", replace=[])
-        assert action.target_files() == ["src/theme.ts"]
+        apply(template, values, work_dir=project)
 
-    def test_file_replace_target_files(self):
-        action = FileReplace(file="assets/logo.png", variable="logo")
-        assert action.target_files() == ["assets/logo.png"]
+        # File should be unchanged
+        data = json.loads((project / "config.json").read_text())
+        assert data["name"] == "original"
 
-    def test_html_replace_target_files(self):
-        action = HtmlReplace(file="index.html", replace=[])
-        assert action.target_files() == ["index.html"]
+    def test_mixed_set_and_unset_in_replace_list(self, tmp_path, project, values_dir):
+        """Only the set variable's replacement is applied."""
+        template = _make_template(
+            tmp_path,
+            [
+                {
+                    "action": "json_replace",
+                    "file": "config.json",
+                    "replace": [
+                        {"selector": "$.name", "variable": "app_name"},
+                        {"selector": "$.theme", "variable": "theme_color"},
+                    ],
+                },
+            ],
+            variables=[
+                {"variable": "app_name", "description": "Name", "default": "original"},
+                {"variable": "theme_color", "description": "Color"},
+            ],
+        )
+        values = _make_values(values_dir, {"app_name": "NewApp"})
+
+        apply(template, values, work_dir=project)
+
+        data = json.loads((project / "config.json").read_text())
+        assert data["name"] == "NewApp"
+        assert "theme" not in data
+
+    def test_all_variables_unset_no_changes(self, tmp_path, project, values_dir):
+        """When all variables are unset, no actions run and files are unchanged."""
+        template = _make_template(
+            tmp_path,
+            [
+                {
+                    "action": "json_replace",
+                    "file": "config.json",
+                    "replace": [{"selector": "$.name", "variable": "optional_var"}],
+                },
+            ],
+            variables=[
+                {"variable": "optional_var", "description": "Optional"},
+            ],
+        )
+        values = _make_values(values_dir, {})
+
+        apply(template, values, work_dir=project)
+
+        data = json.loads((project / "config.json").read_text())
+        assert data["name"] == "original"


### PR DESCRIPTION
Make variable `default` optional. Variables without a default and no provided value are skipped — actions referencing them are never created. Switch template variables from dict to array format for consistency with customizations. Flatten actions to single-variable, fully resolved at construction with zero-arg `apply()`.