### PR TITLE
feat: release @smartcompanion/engraft to npm alongside PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,36 +5,47 @@ on:
     types: [published]
 
 jobs:
-  lint:
+  py-lint:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
           cache: pip
-      - run: pip install -e ".[dev]"
+          cache-dependency-path: python/pyproject.toml
+      - run: pip install -e .[dev]
       - run: ruff check .
       - run: ruff format --check .
 
-  test:
-    needs: lint
+  py-test:
+    needs: py-lint
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10", "3.12", "3.13"]
+    defaults:
+      run:
+        working-directory: python
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-      - run: pip install -e ".[dev]"
+          cache-dependency-path: python/pyproject.toml
+      - run: pip install -e .[dev]
       - run: pytest
 
-  build:
-    needs: test
+  py-build:
+    needs: py-test
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
     steps:
       - uses: actions/checkout@v4
         with:
@@ -43,15 +54,107 @@ jobs:
         with:
           python-version: "3.13"
           cache: pip
+          cache-dependency-path: python/pyproject.toml
       - run: pip install build
       - run: python -m build
       - uses: actions/upload-artifact@v4
         with:
-          name: dist
-          path: dist/
+          name: py-dist
+          path: python/dist/
 
-  publish:
-    needs: build
+  ts-lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: typescript/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+
+  ts-test:
+    needs: ts-lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: typescript/package-lock.json
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+
+  ts-build:
+    needs: ts-test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: typescript/package-lock.json
+      - run: npm ci
+      - name: Set version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          npm pkg set version="$VERSION"
+      - run: npm run build
+      - run: npm pack
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ts-dist
+          path: |
+            typescript/*.tgz
+            typescript/package.json
+
+  e2e:
+    needs: [py-build, ts-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: python/pyproject.toml
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - uses: actions/download-artifact@v4
+        with:
+          name: py-dist
+          path: py-dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: ts-dist
+          path: ts-dist/
+      - name: Install Python wheel
+        run: pip install py-dist/*.whl
+      - name: Stage TypeScript bundle for e2e harness
+        run: |
+          mkdir -p typescript/dist
+          tar -xzf ts-dist/*.tgz -C /tmp
+          cp /tmp/package/dist/cli.js typescript/dist/cli.js
+      - name: Install e2e test dependencies
+        run: pip install pytest
+      - run: pytest e2e/
+
+  py-publish:
+    needs: e2e
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -59,8 +162,29 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: dist
+          name: py-dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           attestations: true
+
+  ts-publish:
+    needs: e2e
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: https://registry.npmjs.org
+      - uses: actions/download-artifact@v4
+        with:
+          name: ts-dist
+          path: ts-dist/
+      - name: Publish to npm
+        run: npm publish ts-dist/*.tgz
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -26,7 +26,7 @@ The original project stays untouched. Run `engraft apply` and the customizations
 Requires Node.js 20 or newer.
 
 ```
-npm install -g engraft
+npm install -g @smartcompanion/engraft
 ```
 
 ## Quick Start

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "engraft",
-  "version": "0.1.0",
+  "name": "@smartcompanion/engraft",
+  "version": "0.0.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "engraft",
-      "version": "0.1.0",
+      "name": "@smartcompanion/engraft",
+      "version": "0.0.0-dev",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "commander": "^12.1.0",
         "js-yaml": "^4.1.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,7 +1,17 @@
 {
-  "name": "engraft",
-  "version": "0.1.0",
+  "name": "@smartcompanion/engraft",
+  "version": "0.0.0-dev",
   "description": "Apply customizations to any project without templating placeholders",
+  "license": "BSD-2-Clause",
+  "homepage": "https://github.com/smartcompanion-app/engraft#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/smartcompanion-app/engraft.git",
+    "directory": "typescript"
+  },
+  "bugs": {
+    "url": "https://github.com/smartcompanion-app/engraft/issues"
+  },
   "type": "module",
   "bin": {
     "engraft": "dist/cli.js"
@@ -11,6 +21,10 @@
   ],
   "engines": {
     "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
## Summary

- Extends the release pipeline so a single GitHub Release tag publishes both Python (`engraft` to PyPI) and TypeScript (`@smartcompanion/engraft` to npm) implementations from the same `vX.Y.Z` source of truth.
- Renames the npm package to `@smartcompanion/engraft` with publish metadata (repository, license, homepage, bugs, `publishConfig` for public scoped access + provenance).
- Fixes the latent `python/` working-directory bug in the Python release jobs (same fix that landed in `pr.yml` for #7).

Job graph:

```
py-lint → py-test (3.10/3.12/3.13) → py-build ─┐
ts-lint → ts-test                  → ts-build ─┴→ e2e ─┬→ py-publish (PyPI)
                                                       └→ ts-publish (npm)
```

The e2e gate consumes the same artifacts that will be published, so parity is verified against the exact bytes about to ship.

## Pre-requisites before first npm publish

- [x] Add `NPM_TOKEN` repo secret (npm automation token with publish rights to the `smartcompanion` scope).
- [ ] Optionally create an `npm` GitHub Environment to gate publishes behind manual approval (mirrors the existing `pypi` environment).

The IDE may warn `Value 'npm' is not valid` on `environment: npm` until that environment exists in the repo. GitHub auto-creates referenced environments at deploy time, so it's an IDE-only diagnostic.

## Test plan

- [x] `npm ci && npm run lint && npm run build && npm test` in `typescript/` — green
- [x] Simulated CI e2e flow locally: `npm pack` → extract tarball → stage at `typescript/dist/cli.js` → `pytest e2e/` → 14 passed
- [ ] Cut a `vX.Y.Z-rc1` pre-release on GitHub and verify the full release workflow end-to-end before tagging a real release

🤖 Generated with [Claude Code](https://claude.com/claude-code)