### PR TITLE
fix(ci): hydrate typescript runtime deps in release e2e job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: npm
+          cache-dependency-path: typescript/package-lock.json
       - uses: actions/download-artifact@v4
         with:
           name: py-dist
@@ -144,6 +146,9 @@ jobs:
           path: ts-dist/
       - name: Install Python wheel
         run: pip install py-dist/*.whl
+      - name: Install TypeScript runtime deps
+        working-directory: typescript
+        run: npm ci --omit=dev
       - name: Stage TypeScript bundle for e2e harness
         run: |
           mkdir -p typescript/dist


### PR DESCRIPTION
## Summary

The v0.2.0 release pipeline failed at the e2e gate with `Cannot find package 'commander'`. The bundle (`tsup`) leaves runtime deps external (declared in `package.json`), and the release e2e job only staged `dist/cli.js` — there was no `typescript/node_modules` for Node to resolve `commander`/`js-yaml`/`jsdom` from.

Run `npm ci --omit=dev` in `typescript/` before staging the tarball so the harness sees the same dep tree a real `npm install -g` consumer gets. Also enable npm cache on the `setup-node` step.

Verified locally by reproducing the CI flow (no `node_modules` → `npm ci --omit=dev` → drop tarball `cli.js` into `typescript/dist/` → `pytest e2e/`): all 14 fixtures pass.

## Next steps after this merges

1. Delete the failed `v0.2.0` GitHub Release + tag (no artifacts shipped — both publishes were skipped after e2e failed).
2. Re-cut the `v0.2.0` release once this is on main.

## Test plan

- [x] Local sim of CI e2e flow with no pre-existing `node_modules` — 14 passed
- [ ] Re-cut `v0.2.0` after merge and confirm the full pipeline (including `py-publish` + `ts-publish`) runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)