### PR TITLE
fix(ts): make CLI work when invoked through an npm bin symlink

### DIFF
--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -50,9 +50,12 @@ export const buildProgram = (): Command => {
 const isMain = (): boolean => {
   if (!process.argv[1]) return false;
   try {
-    return (
-      fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
-    );
+    // npm installs bins as symlinks (node_modules/.bin/engraft → dist/cli.js),
+    // so argv[1] and import.meta.url disagree until both are realpath'd.
+    const here = realpathSync(fileURLToPath(import.meta.url));
+    const argv1 = path.resolve(process.argv[1]);
+    const invoked = existsSync(argv1) ? realpathSync(argv1) : argv1;
+    return here === invoked;
   } catch {
     return false;
   }

--- a/typescript/tests/cli.test.ts
+++ b/typescript/tests/cli.test.ts
@@ -1,5 +1,13 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -77,5 +85,63 @@ customizations:
       readFileSync(path.join(projectDir, "config.json"), "utf8"),
     );
     expect(data.name).toBe("CliApp");
+  });
+
+  // Regression test for the silent no-op bug: when invoked via an npm bin
+  // symlink, isMain() must still recognise the entry point. argv[1] points at
+  // the unresolved symlink, while import.meta.url resolves to the real file —
+  // both sides need to be normalised before comparing.
+  it("apply works when invoked through a symlink (npm bin shape)", () => {
+    if (!existsSync(cliPath)) return;
+
+    const root = mkdtempSync(path.join(tmpdir(), "engraft-cli-symlink-"));
+    const projectDir = path.join(root, "project");
+    const binDir = path.join(root, "bin");
+    mkdirSync(projectDir, { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+
+    writeFileSync(
+      path.join(projectDir, "config.json"),
+      JSON.stringify({ name: "original" }, null, 2) + "\n",
+    );
+    writeFileSync(
+      path.join(root, "template.yml"),
+      `variables:
+  name:
+    description: name
+    default: original
+customizations:
+  - action: json_replace
+    file: config.json
+    replace:
+      - selector: "$.name"
+        variable: name
+`,
+    );
+    writeFileSync(path.join(root, "values.yml"), "name: ViaSymlink\n");
+
+    chmodSync(cliPath, 0o755);
+    const symlinkPath = path.join(binDir, "engraft");
+    symlinkSync(cliPath, symlinkPath);
+
+    const result = spawnSync(
+      "node",
+      [
+        symlinkPath,
+        "apply",
+        "--template",
+        path.join(root, "template.yml"),
+        "--values",
+        path.join(root, "values.yml"),
+      ],
+      { cwd: projectDir, encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Done.");
+    const data = JSON.parse(
+      readFileSync(path.join(projectDir, "config.json"), "utf8"),
+    );
+    expect(data.name).toBe("ViaSymlink");
   });
 });


### PR DESCRIPTION
## Summary

- `isMain()` now `realpathSync()`s both `import.meta.url` and `argv[1]` before comparing, so the entry-point guard recognises the CLI when invoked through `node_modules/.bin/engraft` (an npm-managed symlink to `dist/cli.js`). Before this fix, the realpath'd module URL was compared against the unresolved symlink path, the guard returned `false`, and `npx engraft apply ...` exited 0 silently with no customizations applied.
- Adds a vitest regression test that creates a symlink to the built `dist/cli.js`, spawns it via `node`, and asserts the target fixture file is actually modified — the original bug was silent success, so checking only exit code or stdout would not catch a regression.

Affects every consumer that invokes the CLI via `npx`, `node_modules/.bin/engraft`, or any other npm bin shim. Affected published versions: `@smartcompanion/engraft@0.2.1` and earlier. Suggested release: patch bump to `0.2.2`.

## Test plan

- [x] `npm run lint` (tsc --noEmit) clean
- [x] `npm test` — 40 passed (was 1 failing on the new test before the fix)
- [x] `ENGRAFT_IMPL=typescript pytest e2e/` — 7 passed, 7 skipped
- [x] Manual repro: `ln -s dist/cli.js bin/engraft && node bin/engraft apply ...` now prints `Done.` and modifies the target file (was silent before)
- [ ] Maintainer to cut `v0.2.2` GitHub Release after merge — release pipeline injects the version from the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)